### PR TITLE
Handle missing Firebase config during build

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,14 +1,24 @@
-import { initializeApp, getApps, getApp } from "firebase/app";
-import { getFirestore } from "firebase/firestore";
-import { getAuth } from "firebase/auth";
-import { getStorage } from "firebase/storage";
+import { initializeApp, getApps, getApp, type FirebaseApp } from "firebase/app";
+import { getFirestore, type Firestore } from "firebase/firestore";
+import { getAuth, type Auth } from "firebase/auth";
+import { getStorage, type FirebaseStorage } from "firebase/storage";
 import { firebaseConfig } from "./firebase-config";
 
+// Initialize Firebase only in the browser and when config is available
+let app: FirebaseApp;
+let db: Firestore;
+let auth: Auth;
+let storage: FirebaseStorage;
 
-// Initialize Firebase
-const app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
-const db = getFirestore(app);
-const auth = getAuth(app);
-const storage = getStorage(app);
+if (typeof window !== "undefined" && firebaseConfig.apiKey) {
+  try {
+    app = !getApps().length ? initializeApp(firebaseConfig) : getApp();
+    db = getFirestore(app);
+    auth = getAuth(app);
+    storage = getStorage(app);
+  } catch (error) {
+    console.error("Firebase initialization error:", error);
+  }
+}
 
-export { db, auth, storage };
+export { app, db, auth, storage };

--- a/src/services/clientService.ts
+++ b/src/services/clientService.ts
@@ -2,10 +2,16 @@ import { db } from '@/lib/firebase';
 import { collection, getDocs, doc, setDoc, deleteDoc } from 'firebase/firestore';
 import type { Client } from '@/lib/types';
 
+function getDb() {
+    if (!db) {
+        throw new Error('Firestore has not been initialized');
+    }
+    return db;
+}
+
 export async function getClients(): Promise<Client[]> {
     try {
-        const clientsCol = collection(db, 'clients');
-        const clientSnapshot = await getDocs(clientsCol);
+        const clientSnapshot = await getDocs(collection(getDb(), 'clients'));
         if (clientSnapshot.empty) {
             console.log('No clients found in Firestore.');
             return [];
@@ -20,9 +26,10 @@ export async function getClients(): Promise<Client[]> {
 
 export async function addClient(client: Omit<Client, 'id'>): Promise<Client> {
     try {
-        const newId = doc(collection(db, 'clients')).id;
+        const dbInstance = getDb();
+        const newId = doc(collection(dbInstance, 'clients')).id;
         const newClient: Client = { ...client, id: newId };
-        await setDoc(doc(db, "clients", newId), newClient);
+        await setDoc(doc(dbInstance, "clients", newId), newClient);
         return newClient;
     } catch (error) {
         console.error("Error adding client: ", error);
@@ -32,7 +39,7 @@ export async function addClient(client: Omit<Client, 'id'>): Promise<Client> {
 
 export async function updateClient(client: Client): Promise<void> {
     try {
-        const clientRef = doc(db, "clients", client.id);
+        const clientRef = doc(getDb(), "clients", client.id);
         await setDoc(clientRef, client, { merge: true });
     } catch (error) {
         console.error("Error updating client: ", error);
@@ -42,7 +49,7 @@ export async function updateClient(client: Client): Promise<void> {
 
 export async function deleteClient(clientId: string): Promise<void> {
     try {
-        await deleteDoc(doc(db, "clients", clientId));
+        await deleteDoc(doc(getDb(), "clients", clientId));
     } catch (error) {
         console.error("Error deleting client: ", error);
         throw new Error("Failed to delete client.");

--- a/src/services/knowledgeBaseService.ts
+++ b/src/services/knowledgeBaseService.ts
@@ -3,7 +3,12 @@ import { db } from '@/lib/firebase';
 import { collection, doc, getDocs, getDoc, setDoc, deleteDoc, query, where, onSnapshot } from 'firebase/firestore';
 import type { KnowledgeBaseArticle as Article } from '@/lib/types';
 
-const articlesCollection = collection(db, 'knowledge-base');
+function getDb() {
+    if (!db) {
+        throw new Error('Firestore has not been initialized');
+    }
+    return db;
+}
 
 function createSlug(title: string): string {
     return title
@@ -14,7 +19,7 @@ function createSlug(title: string): string {
 
 export function listenToArticles(callback: (articles: Article[]) => void): () => void {
     try {
-        const unsubscribe = onSnapshot(articlesCollection, (snapshot) => {
+        const unsubscribe = onSnapshot(collection(getDb(), 'knowledge-base'), (snapshot) => {
             if (snapshot.empty) {
                 callback([]);
                 return;
@@ -31,10 +36,11 @@ export function listenToArticles(callback: (articles: Article[]) => void): () =>
 
 export async function addArticle(articleData: Omit<Article, 'id' | 'slug'>): Promise<Article> {
     try {
-        const newId = doc(articlesCollection).id;
+        const dbInstance = getDb();
+        const newId = doc(collection(dbInstance, 'knowledge-base')).id;
         const slug = createSlug(articleData.title);
         const newArticle: Article = { ...articleData, id: newId, slug };
-        await setDoc(doc(db, "knowledge-base", newId), newArticle);
+        await setDoc(doc(dbInstance, "knowledge-base", newId), newArticle);
         return newArticle;
     } catch (error) {
         console.error("Error adding article: ", error);
@@ -44,7 +50,7 @@ export async function addArticle(articleData: Omit<Article, 'id' | 'slug'>): Pro
 
 export async function getArticleBySlug(slug: string): Promise<Article | null> {
     try {
-        const q = query(articlesCollection, where("slug", "==", slug));
+        const q = query(collection(getDb(), 'knowledge-base'), where("slug", "==", slug));
         const snapshot = await getDocs(q);
         if (snapshot.empty) {
             console.log('No matching article found.');
@@ -62,7 +68,7 @@ export async function updateArticle(article: Article): Promise<void> {
         // If the title changed, the slug might need to change.
         const newSlug = createSlug(article.title);
         const articleWithSlug = { ...article, slug: newSlug };
-        const articleRef = doc(db, "knowledge-base", article.id);
+        const articleRef = doc(getDb(), "knowledge-base", article.id);
         await setDoc(articleRef, articleWithSlug, { merge: true });
     } catch (error) {
         console.error("Error updating article: ", error);
@@ -72,7 +78,7 @@ export async function updateArticle(article: Article): Promise<void> {
 
 export async function deleteArticle(articleId: string): Promise<void> {
     try {
-        await deleteDoc(doc(db, "knowledge-base", articleId));
+        await deleteDoc(doc(getDb(), "knowledge-base", articleId));
     } catch (error) {
         console.error("Error deleting article: ", error);
         throw new Error("Failed to delete article.");

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -5,9 +5,30 @@ import type { TeamMember } from '@/lib/types';
 import { type User, updateProfile } from 'firebase/auth';
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 
+function getDb() {
+    if (!db) {
+        throw new Error('Firestore has not been initialized');
+    }
+    return db;
+}
+
+function getStorage() {
+    if (!storage) {
+        throw new Error('Storage has not been initialized');
+    }
+    return storage;
+}
+
+function getAuthInstance() {
+    if (!auth) {
+        throw new Error('Auth has not been initialized');
+    }
+    return auth;
+}
+
 export function listenToTeamMembers(callback: (team: TeamMember[]) => void): () => void {
     try {
-        const teamCol = collection(db, 'team');
+        const teamCol = collection(getDb(), 'team');
         const unsubscribe = onSnapshot(teamCol, (teamSnapshot) => {
             if (teamSnapshot.empty) {
                 console.log('No team members found in Firestore.');
@@ -26,7 +47,7 @@ export function listenToTeamMembers(callback: (team: TeamMember[]) => void): () 
 
 export async function upsertTeamMemberFromUser(user: User): Promise<void> {
     try {
-        const teamMemberRef = doc(db, "team", user.uid);
+        const teamMemberRef = doc(getDb(), "team", user.uid);
         const docSnap = await getDoc(teamMemberRef);
 
         if (!docSnap.exists()) {
@@ -57,7 +78,7 @@ export async function upsertTeamMemberFromUser(user: User): Promise<void> {
 
 export async function updateTeamMember(teamMember: TeamMember): Promise<void> {
     try {
-        const teamMemberRef = doc(db, "team", teamMember.id);
+        const teamMemberRef = doc(getDb(), "team", teamMember.id);
         await setDoc(teamMemberRef, teamMember, { merge: true });
     } catch (error) {
         console.error("Error updating team member: ", error);
@@ -67,7 +88,7 @@ export async function updateTeamMember(teamMember: TeamMember): Promise<void> {
 
 export async function deleteTeamMember(teamMemberId: string): Promise<void> {
     try {
-        await deleteDoc(doc(db, "team", teamMemberId));
+        await deleteDoc(doc(getDb(), "team", teamMemberId));
     } catch (error) {
         console.error("Error deleting team member: ", error);
         throw new Error("Failed to delete team member.");
@@ -75,13 +96,13 @@ export async function deleteTeamMember(teamMemberId: string): Promise<void> {
 }
 
 export async function uploadProfilePicture(file: File, userId: string): Promise<string> {
-    const currentUser = auth.currentUser;
+    const currentUser = getAuthInstance().currentUser;
     if (!currentUser || currentUser.uid !== userId) {
         throw new Error("Authentication error: User is not authorized to perform this action.");
     }
     
     try {
-        const storageRef = ref(storage, `profile-pictures/${userId}`);
+        const storageRef = ref(getStorage(), `profile-pictures/${userId}`);
         const snapshot = await uploadBytes(storageRef, file);
         const downloadURL = await getDownloadURL(snapshot.ref);
 
@@ -89,7 +110,7 @@ export async function uploadProfilePicture(file: File, userId: string): Promise<
         await updateProfile(currentUser, { photoURL: downloadURL });
         
         // Update Firestore team member document
-        const teamMemberRef = doc(db, "team", userId);
+        const teamMemberRef = doc(getDb(), "team", userId);
         await setDoc(teamMemberRef, { photoURL: downloadURL }, { merge: true });
 
         return downloadURL;


### PR DESCRIPTION
## Summary
- init Firebase only on client and gracefully handle missing config
- lazily acquire Firestore in service modules to prevent build-time errors

## Testing
- `npm run typecheck`
- `npm run build -- --no-lint`
- `npm test` *(fails: Missing script "test"*)


------
https://chatgpt.com/codex/tasks/task_e_689375960ec083289da5c9ac0851e65b